### PR TITLE
Made code more rust idiomatic

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -17,16 +17,18 @@ impl SecretKey {
     }
     pub fn from_slice(bytes: &[u8]) -> Self {
         let mut b = [0u8; 32];
-        b.copy_from_slice(&bytes);
+        b.copy_from_slice(bytes);
         SecretKey { bytes: b }
     }
 
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
+
     pub fn to_bytes(&self) -> [u8; 32] {
         self.bytes
     }
+
     pub fn extract_public_key_and_scalar(&self) -> (PublicKey, Scalar) {
         let mut hasher = Sha512::new();
         hasher.update(&self.bytes);
@@ -57,19 +59,23 @@ impl PublicKey {
     pub fn new(point: CompressedEdwardsY) -> Self {
         PublicKey { point }
     }
+
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let mut b = [0u8; 32];
-        b.copy_from_slice(&bytes);
+        b.copy_from_slice(bytes);
         PublicKey {
             point: CompressedEdwardsY::from_slice(&b),
         }
     }
+
     pub fn as_bytes(&self) -> &[u8] {
         self.point.as_bytes()
     }
+
     pub fn to_bytes(&self) -> [u8; 32] {
         self.point.to_bytes()
     }
+
     pub fn as_point(&self) -> &CompressedEdwardsY {
         &self.point
     }
@@ -96,3 +102,4 @@ mod tests {
         assert_eq!(scalar.as_bytes(), secret_scalar.as_slice());
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod keys;
 pub mod proof;
 pub(crate) mod utils;
+

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -13,7 +13,7 @@ impl Proof {
     pub fn new(secret_key: &SecretKey, message: impl AsRef<[u8]>) -> Self {
         prove(secret_key, message.as_ref())
     }
-    
+
     pub fn verify(&self) -> Result<[u8; 64], ()> {
         verify_proof(self)
     }


### PR DESCRIPTION
Went through the code base and changed somethings that will make your
project faster and more idiomatic. For instance: using Vec<u8> instead
of &[u8] -- which offers greater flexibility for the function's
parameter. Check out the Rust design book for more info. Also, I tried
to create more rust-style code. Finally, removed a lot of references that
were not needed.